### PR TITLE
renommer les fichiers pointMeForm en majuscule pour la première lettre

### DIFF
--- a/src/Component/Admin/pointMeForm/PointMeForm.js
+++ b/src/Component/Admin/pointMeForm/PointMeForm.js
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import {collection, getDocs, updateDoc, doc} from 'firebase/firestore';
 import { db } from '../../../firebaseConfig';
 import {BsFillTelephoneFill} from 'react-icons/bs'
-import './pointMeForm.css';
+import './PointMeForm.css';
 
 const PointMeForm = () => {
 


### PR DESCRIPTION
j'avais écris renommer les fichiers js et css de pointMeForm tout en minuscule maintenant seul la première lettre est en majuscule du coup j'ai dû changé le path dans les fichiers concerné